### PR TITLE
Add Timeout.InfiniteTimeSpan and Sleep(timespan)

### DIFF
--- a/source/CoreLibrary.nfproj
+++ b/source/CoreLibrary.nfproj
@@ -370,9 +370,6 @@
     <NFMDP_PE_ExcludeClassByName Include="System.STAThreadAttribute">
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>
-    <NFMDP_PE_ExcludeClassByName Include="System.Threading.Timeout">
-      <InProject>false</InProject>
-    </NFMDP_PE_ExcludeClassByName>
     <NFMDP_PE_ExcludeClassByName Include="System.TypedReference">
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>

--- a/source/System/Threading/Thread.cs
+++ b/source/System/Threading/Thread.cs
@@ -112,11 +112,38 @@ namespace System.Threading
         /// Suspends the current thread for the specified number of milliseconds.
         /// </summary>
         /// <param name="millisecondsTimeout">The number of milliseconds for which the thread is suspended. 
-        /// If the value of the millisecondsTimeout argument is zero, the thread relinquishes the remainder 
+        /// If the value of the <paramref name="millisecondsTimeout"/> argument is zero, the thread relinquishes the remainder 
         /// of its time slice to any thread of equal priority that is ready to run. If there are no other threads 
         /// of equal priority that are ready to run, execution of the current thread is not suspended.</param>
+        /// <remarks>
+        /// The thread will not be scheduled for execution by the operating system for the amount of time specified. 
+        /// You can specify Timeout.Infinite for the <paramref name="millisecondsTimeout"/> parameter to suspend the thread indefinitely. However, we recommend that you use other <see cref="System.Threading"/> classes such as <see cref="AutoResetEvent"/>, <see cref="ManualResetEvent"/>, <see cref="Monitor"/> or <see cref="WaitHandle"/> instead to synchronize threads or manage resources.
+        /// The system clock ticks at a specific rate called the clock resolution. The actual timeout might not be exactly the specified timeout, because the specified timeout will be adjusted to coincide with clock ticks. 
+        /// </remarks>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void Sleep(int millisecondsTimeout);
+
+        /// <summary>
+        /// Suspends the current thread for the specified amount of time.
+        /// </summary>
+        /// <param name="timeout">The amount of time for which the thread is suspended. 
+        /// If the value of the <paramref name="timeout"/> argument is Zero, the thread relinquishes the remainder 
+        /// of its time slice to any thread of equal priority that is ready to run. If there are no other threads 
+        /// of equal priority that are ready to run, execution of the current thread is not suspended.</param>
+        /// <remarks>
+        /// The thread will not be scheduled for execution by the operating system for the amount of time specified. 
+        /// You can specify <see cref="Timeout.Infinite"/> for the <paramref name="timeout"/> parameter to suspend the thread indefinitely. However, we recommend that you use other <see cref="System.Threading"/> classes such as <see cref="AutoResetEvent"/>, <see cref="ManualResetEvent"/>, <see cref="Monitor"/> or <see cref="WaitHandle"/> instead to synchronize threads or manage resources.
+        /// The system clock ticks at a specific rate called the clock resolution. The actual timeout might not be exactly the specified timeout, because the specified timeout will be adjusted to coincide with clock ticks. 
+        /// </remarks>
+        public static void Sleep(TimeSpan timeout)
+        {
+            long tm = timeout.Ticks / TimeSpan.TicksPerMillisecond;
+            if (tm < -1 || tm > Int32.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+            Sleep((int)tm);
+        }
 
         /// <summary>
         /// Gets the currently running thread.

--- a/source/System/Threading/Timeout.cs
+++ b/source/System/Threading/Timeout.cs
@@ -16,6 +16,14 @@ namespace System.Threading
         /// </summary>
         /// <remarks>The value of this field is -1 (0xFFFFFFFF).</remarks>
         public const int Infinite = -1;
-    }
 
+        /// <summary>
+        /// A constant used to specify an infinite waiting period, for methods that accept a <see cref="TimeSpan"/> parameter.
+        /// </summary>
+        /// <remarks>
+        /// For threading methods that accept a timeout parameter of type <see cref="TimeSpan"/>, such as <see cref="Thread.Sleep(TimeSpan)"/> and <see cref="Thread.Join(TimeSpan)"/>, this value is used to suspend the thread indefinitely. However, in most cases, we recommend that you use other <see cref="System.Threading"/> classes such as <see cref="AutoResetEvent"/>, <see cref="ManualResetEvent"/>, <see cref="Monitor"/> or <see cref="WaitHandle"/> instead to synchronize threads or manage resources. 
+        /// The value of this field is -00:00:00.0010000, or -1 millisecond.
+        /// </remarks>
+        public static readonly TimeSpan InfiniteTimeSpan = new TimeSpan(0, 0, 0, 0, Infinite);
+    }
 }


### PR DESCRIPTION
## Description
- Add Timeout.InfiniteTimeSpan
- Add Therad.Sleep overload with timespan
- Improve documentation on Thread.Sleep methods

## Motivation and Context
- Required to handle nanoFramework/Home#318
- Required for other UWP APIs that use  timeouts properties with TimeSpan
- Add missing Sleep overload with TimeSpan which can be handy

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
