### PR TITLE
Remove implementations of GetHashCode() from several classes

### DIFF
--- a/source/System/ComponentModel/EditorBrowsableAttribute.cs
+++ b/source/System/ComponentModel/EditorBrowsableAttribute.cs
@@ -30,7 +30,12 @@ namespace System.ComponentModel
     /// Specifies that a property or method is viewable in an editor. This class cannot be inherited.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate)]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
+    // GetHashCode() implementation is provided by general native function CLR_RT_HeapBlock::GetHashCode //
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
     public sealed class EditorBrowsableAttribute : Attribute
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         private readonly EditorBrowsableState _browsableState;
 
@@ -74,11 +79,5 @@ namespace System.ComponentModel
                 return _browsableState;
             }
         }
-
-        /// <summary>
-        /// Returns the hash code for this instance.
-        /// </summary>
-        /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode() => base.GetHashCode();
     }
 }

--- a/source/System/DateTime.cs
+++ b/source/System/DateTime.cs
@@ -13,7 +13,7 @@ namespace System
     /// <summary>
     /// Specifies whether a DateTime object represents a local time, a Coordinated Universal Time (UTC), or is not specified as either local time or UTC.
     /// </summary>
-    /// <remarks>nanoFramework doesn't suport local time, only  UTC, so it's not possible to specify DateTimeKind.Local.</remarks>
+    /// <remarks>nanoFramework doesn't support local time, only  UTC, so it's not possible to specify DateTimeKind.Local.</remarks>
     [Serializable]
     public enum DateTimeKind
     {
@@ -24,7 +24,7 @@ namespace System
         /// <summary>
         /// The time represented is local time.
         /// </summary>
-        [Obsolete("nanoFrameowrk doesn't support local time, so DateTimeKind.Local can't be used for consistency", true)]
+        [Obsolete("nanoFramework doesn't support local time, so DateTimeKind.Local can't be used for consistency", true)]
         Local = 2,
     }
 

--- a/source/System/Delegate.cs
+++ b/source/System/Delegate.cs
@@ -11,7 +11,14 @@ namespace System
     /// Represents a delegate, which is a data structure that refers to a static method or to a class instance and an instance method of that class.
     /// </summary>
     [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
+#pragma warning disable CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
+    // GetHashCode() implementation is provided by general native function CLR_RT_HeapBlock::GetHashCode //
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
     public abstract class Delegate
+#pragma warning restore CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
 
         /// <summary>
@@ -81,14 +88,5 @@ namespace System
         /// <returns>true if d1 is not equal to d2; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern bool operator !=(Delegate d1, Delegate d2);
-
-        /// <summary>
-        /// Returns the hash code for this instance.
-        /// </summary>
-        /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
-        {
-            return GetType().GetHashCode();
-        }
     }
 }

--- a/source/System/MulticastDelegate.cs
+++ b/source/System/MulticastDelegate.cs
@@ -12,7 +12,14 @@ namespace System
     /// Represents a multicast delegate; that is, a delegate that can have more than one element in its invocation list.
     /// </summary>
     [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
+#pragma warning disable CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
+    // GetHashCode() implementation is provided by general native function CLR_RT_HeapBlock::GetHashCode //
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
     public abstract class MulticastDelegate : Delegate
+#pragma warning restore CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
 
         /// <summary>
@@ -32,15 +39,6 @@ namespace System
         /// <returns>rue if d1 and d2 do not have the same invocation lists; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern bool operator !=(MulticastDelegate d1, MulticastDelegate d2);
-
-        /// <summary>
-        /// Returns the hash code for this instance.
-        /// </summary>
-        /// <returns>A 32-bit signed integer hash code.</returns>
-        public override sealed int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
 
         /// <summary>
         /// Returns the hash code for this instance.

--- a/source/System/String.cs
+++ b/source/System/String.cs
@@ -11,7 +11,14 @@ namespace System
     /// Represents text as a sequence of UTF-16 code units.
     /// </summary>
     [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
+#pragma warning disable CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
+    // GetHashCode() implementation is provided by general native function CLR_RT_HeapBlock::GetHashCode //
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
     public sealed class String : IComparable
+#pragma warning restore CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         /// <summary>
         /// Represents the empty string. This field is read-only.
@@ -770,41 +777,6 @@ namespace System
             else
             {
                 return this + new String(paddingChar, totalWidth - Length);
-            }
-        }
-
-        /// <summary>
-        /// Returns the hash code for this instance.
-        /// </summary>
-        /// <returns>A 32-bit signed integer hash code.</returns>
-        public override int GetHashCode()
-        {
-
-            unsafe
-            {
-                fixed (char* src = this)
-                {
-                    int hash1 = (5381<<16) + 5381;
-                    int hash2 = hash1;
-
-                    // 32 bit machines.
-                    int* pint = (int *)src;
-                    int len = this.Length;
-                    while (len > 2)
-                    {
-                        hash1 = ((hash1 << 5) + hash1 + (hash1 >> 27)) ^ pint[0];
-                        hash2 = ((hash2 << 5) + hash2 + (hash2 >> 27)) ^ pint[1];
-                        pint += 2;
-                        len  -= 4;
-                    }
- 
-                    if (len > 0)
-                    {
-                        hash1 = ((hash1 << 5) + hash1 + (hash1 >> 27)) ^ pint[0];
-                    }
-
-                    return hash1 + (hash2 * 1566083941);
-                }
             }
         }
     }

--- a/source/System/ValueType.cs
+++ b/source/System/ValueType.cs
@@ -13,7 +13,9 @@ namespace System
     /// </summary>
     [Serializable]
 #pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
-    // It would require to implement this on a call to native which seems a waste of resources.
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
+    // GetHashCode() implementation is provided by general native function CLR_RT_HeapBlock::GetHashCode //
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
     public abstract class ValueType
 #pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
- There is a native function that provides the hash code for most of the classes. Despite not being the most efficient implementation it seems that is the option for now.
🚩 for review on a future iteration.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
