### PR TITLE
Constructor should copy only the desired chars

### DIFF
--- a/source/System/Text/StringBuilder.cs
+++ b/source/System/Text/StringBuilder.cs
@@ -190,7 +190,7 @@ Label_0002:
             //Set the length of the chunk
             _chunkLength = length;
             //Copy the value to the chunkChars
-            value.ToCharArray().CopyTo(_chunkChars, 0);
+            value.ToCharArray(startIndex, length).CopyTo(_chunkChars, 0);
         }
 
         private StringBuilder(int size, int maxCapacity, StringBuilder previousBlock)


### PR DESCRIPTION
## Description
If startIndex is not zero and length not value.length the last line in the constructor would throw an exception.

## Motivation and Context
Found that during unit testing

## How Has This Been Tested?
With this change the call ```StringBuilder sb = new StringBuilder("nanoFramework", 4, 5, 7)``` works correctly. Without this change the call throws an exception.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>
