### PR TITLE
Fix PostProcessInteger in System.Number

### DIFF
--- a/source/System/Number.cs
+++ b/source/System/Number.cs
@@ -413,10 +413,10 @@ namespace System
                 result = InsertGroupSeparators(result, info);
             }
 
-            result = ReplaceDecimalSeperator(result, info);
-            result = ReplaceNegativeSign(result, info);
             result = AppendFloatTrailingZeros(result, precision, info);
-
+			result = ReplaceDecimalSeperator(result, info);
+            result = ReplaceNegativeSign(result, info);
+            
             return result;
         }
 


### PR DESCRIPTION
## Description
If we ReplaceDecimalSeperator first then the AppendFloatTrailingZeros doesn't find the decimal point. So we should first append the trailing zeros, then replace the decimal point and at least we should replace the negative sign.

## Motivation and Context
During fixing nanoFramework/Home#406 I've found that this would not be working if the decimal point is replaced first.

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch info@matthias-jentsch.de
