### PR TITLE
Fix Assembly.GetType(string, bool) throws ArgumentException

### DIFF
--- a/source/System/Reflection/Assembly.cs
+++ b/source/System/Reflection/Assembly.cs
@@ -127,7 +127,7 @@ namespace System.Reflection
         {
             var type = GetType(name);
 
-            if (type == null) throw new ArgumentException();
+            if ( (type == null) && (throwOnError) ) throw new ArgumentException();
 
             return type;
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
The Assembly.GetType(string, bool) implementation was faulty, it ignored the bool argument.
- Fixes nanoFramework/Home#398

## How Has This Been Tested?
Tested with the following code. Original mscorlib threw exception no matter the bool value. Reached line never reached. After the fix, if bool value is false, Reached is printed to the console. With the value set to true, the exception is still thrown.
```
using System;
using System.Reflection;

namespace NFApp1
{
	public class Program
	{
		public static void Main()
		{
			Assembly a = Assembly.GetAssembly(typeof(Program));
			Type t = a.GetType("NotExistingType", false);

                        Console.WriteLine("Reached");
		}
	}
}
```
## Screenshots

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: NemesisXB <485436+NemesisXB@users.noreply.github.com>
