### PR TITLE
Add option to remove AppDomains APIs with compiler constant

### DIFF
--- a/source/CoreLibrary.nfproj
+++ b/source/CoreLibrary.nfproj
@@ -21,6 +21,7 @@
     <OutputName>mscorlib</OutputName>
     <IsCoreAssembly>true</IsCoreAssembly>
     <IsMscorlib>true</IsMscorlib>
+    <DefineConstants>$(DefineConstants);NANOCLR_APPDOMAINS</DefineConstants>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
     <DocumentationFile>bin\$(Configuration)\mscorlib.xml</DocumentationFile>
   </PropertyGroup>

--- a/source/System/AppDomain.cs
+++ b/source/System/AppDomain.cs
@@ -4,6 +4,12 @@
 // See LICENSE file in the project root for full license information.
 //
 
+///////////////////////////////////////////////////
+// DEV NOTE: to enable the AppDomain API add     //
+// 'NANOCLR_APPDOMAINS' to the compile constants //
+///////////////////////////////////////////////////
+#if (NANOCLR_APPDOMAINS)
+
 using System.Reflection;
 using System.Threading;
 using System.Runtime.CompilerServices;
@@ -113,3 +119,4 @@ namespace System
         public static extern void Unload(AppDomain domain);
     }
 }
+#endif // #if (NANOCLR_APPDOMAINS)

--- a/source/System/Threading/Thread.cs
+++ b/source/System/Threading/Thread.cs
@@ -168,11 +168,16 @@ namespace System.Threading
             get;
         }
 
+#if (NANOCLR_APPDOMAINS)
+
         /// <summary>
         /// Returns the current domain in which the current thread is running.
         /// </summary>
         /// <returns>An AppDomain representing the current application domain of the running thread.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern AppDomain GetDomain();
+
+#endif // #if (NANOCLR_APPDOMAINS)
+
     }
 }


### PR DESCRIPTION
## Description
- Wrap AppDomains method with compiler define
- Add compiler constant to include AppDomains (matching the one used in the native repo, for clarity)

## Motivation and Context
- Work towards having a flavoured mscorlib

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
