### PR TITLE
Fix bug in FromBase64CharArray

### DIFF
--- a/source/nanoFramework.CoreLibrary/System/Convert.cs
+++ b/source/nanoFramework.CoreLibrary/System/Convert.cs
@@ -293,7 +293,7 @@ namespace System
             var destinationArray = new char[length];
             Array.Copy(inArray, offset, destinationArray, 0, length);
 
-            return FromBase64CharArray(inArray, length);
+            return FromBase64CharArray(destinationArray, length);
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
## Description
We should deliver the new array to the native code method. Otherwise it wouldn't work for offsets != 0

## Motivation and Context
Found that ```Convert.FromBase64CharArray``` is not working with an offset.

## How Has This Been Tested?
It's obvious that it should be implemented that way.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Matthias Jentsch <info@matthias-jentsch.de>
