### PR TITLE
Remove DebuggerBrowsable from excluded classes

### DIFF
--- a/source/nanoFramework.CoreLibrary/CoreLibrary.nfproj
+++ b/source/nanoFramework.CoreLibrary/CoreLibrary.nfproj
@@ -226,12 +226,6 @@
     <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggableAttribute">
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>
-    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerBrowsableAttribute">
-      <InProject>false</InProject>
-    </NFMDP_PE_ExcludeClassByName>
-    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerBrowsableState">
-      <InProject>false</InProject>
-    </NFMDP_PE_ExcludeClassByName>
     <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerDisplayAttribute">
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>


### PR DESCRIPTION
## Description
- Remove DebuggerBrowsable from excluded classes.

## Motivation and Context
- These are being used in other class libs therefore can't be excluded.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

