### PR TITLE
TryParseGuidWithDashes added along with string based constructor.

### DIFF
--- a/source/nanoFramework.CoreLibrary/System/Guid.cs
+++ b/source/nanoFramework.CoreLibrary/System/Guid.cs
@@ -12,7 +12,7 @@ namespace System
         ////////////////////////////////////////////////////////////////////////////////
         //  Member variables
         ////////////////////////////////////////////////////////////////////////////////
-        private int   _a;
+        private int _a;
         private short _b;
         private short _c;
         private byte _d;
@@ -128,6 +128,7 @@ namespace System
         ///   then 12) such as: "CA761232-ED42-11CE-BACD-00AA0057B223"
         /// </summary>
         /// <param name="g">String representation of new <see cref="Guid"/>.</param>
+        /// <exception cref="ArgumentException"></exception>
         public Guid(string g)
         {
             if (!TryParseGuidWithDashes(g, out this))
@@ -418,35 +419,21 @@ namespace System
             }
 
             currentPos = startPos;
-            if (!StringToInt(guidString, ref currentPos, 8, out temp))
+            try
             {
-                return false;
+                result._a = (int)HexStringToLong(guidString, ref currentPos, 8);
+                ++currentPos; // Increment past the '-'
+                result._b = (short)HexStringToLong(guidString, ref currentPos, 4);
+                ++currentPos; // Increment past the '-'
+                result._c = (short)HexStringToLong(guidString, ref currentPos, 4);
+                ++currentPos; // Increment past the '-'
+                temp = (int)HexStringToLong(guidString, ref currentPos, 4);
+                ++currentPos; // Increment past the '-'
+                templ = HexStringToLong(guidString, ref currentPos, 12);
             }
-            result._a = temp;
-            ++currentPos; // Increment past the '-'
-
-            if (!StringToInt(guidString, ref currentPos, 4, out temp))
+            catch
             {
-                return false;
-            }
-            result._b = (short)temp;
-            ++currentPos; // Increment past the '-'
-
-            if (!StringToInt(guidString, ref currentPos, 4, out temp))
-            {
-                return false;
-            }
-            result._c = (short)temp;
-            ++currentPos; // Increment past the '-'
-
-            if (!StringToInt(guidString, ref currentPos, 4, out temp))
-            {
-                return false;
-            }
-            ++currentPos; // Increment past the '-'            
-
-            if (!StringToLong(guidString, ref currentPos, 12, out templ))
-            {
+                result = Guid.Empty;
                 return false;
             }
 
@@ -465,66 +452,17 @@ namespace System
         }
 
         /// <summary>
-        /// Using StringToLong to convert a hex sub-string to an int, while incrementing the parsePos.
+        /// Converts a hex sub-string to a long, while incrementing the parsePos.
         /// </summary>
         /// <param name="str">The string containing the hex sub-string.</param>
         /// <param name="parsePos">The position of the hex sub-string within str.</param>
         /// <param name="requiredLength">The length of the hex sub-string.</param>
-        /// <param name="result">The numeric value of the hex string.</param>
         /// <returns>False if any character is not a hex digit or string is shorter than needed for the requiredLength. Otherwise true.</returns>
-        private static bool StringToInt(String str, ref int parsePos, int requiredLength, out int result)
+        private static long HexStringToLong(String str, ref int parsePos, int requiredLength)
         {
-            if (StringToLong(str, ref parsePos, requiredLength, out long lresult))
-            {
-                result = (int)lresult;
-                return true;
-            }
-            else
-            {
-                result = 0;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Converts a hex sub-string to a long with the most basic tools, while incrementing the parsePos.
-        /// </summary>
-        /// <param name="str">The string containing the hex sub-string.</param>
-        /// <param name="parsePos">The position of the hex sub-string within str.</param>
-        /// <param name="requiredLength">The length of the hex sub-string.</param>
-        /// <param name="result">The numeric value of the hex string.</param>
-        /// <returns>False if any character is not a hex digit or string is shorter than needed for the requiredLength. Otherwise true.</returns>
-        private static bool StringToLong(String str, ref int parsePos, int requiredLength, out long result)
-        {
-            result = 0;
-
-            if (str.Length < parsePos + requiredLength)
-            {
-                return false;
-            }
-            while (requiredLength-- > 0)
-            {
-                result <<= 4;
-                char c = str[parsePos++];
-                if (c >= '0' && c <= '9')
-                {
-                    result += (byte)c - 48;
-                }
-                else if (c >= 'A' && c <= 'F')
-                {
-                    result += (byte)c - 55;
-                }
-                else if (c >= 'a' && c <= 'f')
-                {
-                    result += (byte)c - 87;
-                }
-                else
-                {
-                    return false;
-                }
-            }
-            return true;
+            long result = Convert.ToInt64(str.Substring(parsePos, requiredLength), 16);
+            parsePos += requiredLength;
+            return result;
         }
     }
 }
-

--- a/source/nanoFramework.CoreLibrary/System/Guid.cs
+++ b/source/nanoFramework.CoreLibrary/System/Guid.cs
@@ -12,7 +12,7 @@ namespace System
         ////////////////////////////////////////////////////////////////////////////////
         //  Member variables
         ////////////////////////////////////////////////////////////////////////////////
-        private int _a;
+        private int   _a;
         private short _b;
         private short _c;
         private byte _d;
@@ -131,7 +131,9 @@ namespace System
         public Guid(string g)
         {
             if (!TryParseGuidWithDashes(g, out this))
-                throw new ArgumentException();
+            {
+                throw new ArgumentException("Guid string not in expected format: [{]dddddddd-dddd-dddd-dddd-dddddddddddd[}]");
+            }
         }
 
         /// <summary>
@@ -373,55 +375,81 @@ namespace System
             return 1;
         }
 
-
-        // Check if it's of the form [{|(]dddddddd-dddd-dddd-dddd-dddddddddddd[}|)]
+        /// <summary>
+        ///   Creates a new <see cref="Guid"/> based on the value in the string.  The value is made up
+        ///   of hex digits speared by the dash ("-"). The string may begin and end with
+        ///   brackets ("{", "}").
+        ///   
+        ///   The string must be of the form dddddddd-dddd-dddd-dddd-dddddddddddd. where
+        ///   d is a hex digit. (That is 8 hex digits, followed by 4, then 4, then 4,
+        ///   then 12) such as: "CA761232-ED42-11CE-BACD-00AA0057B223"
+        /// </summary>
+        /// <param name="guidString">Guid string to parse.</param>
+        /// <param name="result">Resulting Guid.</param>
+        /// <returns></returns>
         public static bool TryParseGuidWithDashes(String guidString, out Guid result)
         {
             int startPos = 0;
             int temp;
             long templ;
             int currentPos = 0;
-            result = new Guid();
+            result = Guid.Empty;
 
             // check to see that it's the proper length
             if (guidString[0] == '{')
             {
                 if (guidString.Length != 38 || guidString[37] != '}')
+                {
                     return false;
+                }
                 startPos = 1;
             }
             else if (guidString.Length != 36)
+            {
                 return false;
+            }
 
             if (guidString[8 + startPos] != '-' ||
                 guidString[13 + startPos] != '-' ||
                 guidString[18 + startPos] != '-' ||
                 guidString[23 + startPos] != '-')
+            {
                 return false;
+            }
 
             currentPos = startPos;
             if (!StringToInt(guidString, ref currentPos, 8, out temp))
+            {
                 return false;
+            }
             result._a = temp;
-            ++currentPos; //Increment past the '-';
+            ++currentPos; // Increment past the '-'
 
             if (!StringToInt(guidString, ref currentPos, 4, out temp))
+            {
                 return false;
+            }
             result._b = (short)temp;
-            ++currentPos; //Increment past the '-';
+            ++currentPos; // Increment past the '-'
 
             if (!StringToInt(guidString, ref currentPos, 4, out temp))
+            {
                 return false;
+            }
             result._c = (short)temp;
-            ++currentPos; //Increment past the '-';
+            ++currentPos; // Increment past the '-'
 
             if (!StringToInt(guidString, ref currentPos, 4, out temp))
+            {
                 return false;
-            ++currentPos; //Increment past the '-';
+            }
+            ++currentPos; // Increment past the '-'
             startPos = currentPos;
 
             if (!StringToLong(guidString, ref currentPos, 12, out templ))
+            {
                 return false;
+            }
 
             result._d = (byte)(temp >> 8);
             result._e = (byte)(temp);
@@ -447,12 +475,16 @@ namespace System
         /// <returns>False if any character is not a hex digit or string is shorter than needed for the requiredLength. Otherwise true.</returns>
         private static bool StringToInt(String str, ref int parsePos, int requiredLength, out int result)
         {
-            result = 0;
             if (StringToLong(str, ref parsePos, requiredLength, out long lresult))
+            {
                 result = (int)lresult;
+                return true;
+            }
             else
+            {
+                result = 0;
                 return false;
-            return true;
+            }
         }
 
         /// <summary>
@@ -468,19 +500,29 @@ namespace System
             result = 0;
 
             if (str.Length < parsePos + requiredLength)
+            {
                 return false;
+            }
             while (requiredLength-- > 0)
             {
                 result <<= 4;
                 char c = str[parsePos++];
                 if (c >= '0' && c <= '9')
+                {
                     result += (byte)c - 48;
+                }
                 else if (c >= 'A' && c <= 'F')
+                {
                     result += (byte)c - 55;
+                }
                 else if (c >= 'a' && c <= 'f')
+                {
                     result += (byte)c - 87;
+                }
                 else
+                {
                     return false;
+                }
             }
             return true;
         }

--- a/source/nanoFramework.CoreLibrary/System/Guid.cs
+++ b/source/nanoFramework.CoreLibrary/System/Guid.cs
@@ -443,8 +443,7 @@ namespace System
             {
                 return false;
             }
-            ++currentPos; // Increment past the '-'
-            startPos = currentPos;
+            ++currentPos; // Increment past the '-'            
 
             if (!StringToLong(guidString, ref currentPos, 12, out templ))
             {


### PR DESCRIPTION
## Description
- Additional constructor from Guid string added which uses TryParseGuidWithDashes (also public).

## Motivation and Context
- This was raised as part of issue nanoframework/Home#514.
- Closes nanoframework/Home#514.

## How Has This Been Tested?<!-- (if applicable) -->
This change was tested as part of a .Net Standard project, and ported to nanoFramework.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: Roadrunner67<sbc@bangding.dk>
