### PR TITLE
Bump AssemblyNativeVersion to 100.2.3.0

### DIFF
--- a/source/nanoFramework.CoreLibrary/System/AssemblyInfo.cs
+++ b/source/nanoFramework.CoreLibrary/System/AssemblyInfo.cs
@@ -14,4 +14,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyProduct("nanoFramework mscorlib")]
 [assembly: AssemblyCopyright("Copyright © nanoFramework Contributors 2017")]
 
-[assembly: AssemblyNativeVersion("100.2.2.0")]
+[assembly: AssemblyNativeVersion("100.2.3.0")]


### PR DESCRIPTION
- Required following #88.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

