### PR TITLE
Improvements on double and single types

### DIFF
--- a/source/nanoFramework.CoreLibrary/System/AssemblyInfo.cs
+++ b/source/nanoFramework.CoreLibrary/System/AssemblyInfo.cs
@@ -14,4 +14,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyProduct("nanoFramework mscorlib")]
 [assembly: AssemblyCopyright("Copyright © nanoFramework Contributors 2017")]
 
-[assembly: AssemblyNativeVersion("100.4.3.0")]
+[assembly: AssemblyNativeVersion("100.4.5.0")]

--- a/source/nanoFramework.CoreLibrary/System/Convert.cs
+++ b/source/nanoFramework.CoreLibrary/System/Convert.cs
@@ -202,6 +202,18 @@ namespace System
             return NativeToDouble(value);
         }
 
+#pragma warning disable S4200 // Native methods should be wrapped
+        /// <summary>
+        /// Converts the specified string representation of a number to an equivalent single-precision floating-point number.
+        /// </summary>
+        /// <param name="value">A string that contains the number to convert.</param>
+        /// <returns>A single-precision floating-point number that is equivalent to the number in value, or 0 (zero) if value is <see langword="null"/>.</returns>
+        public static float ToSingle(string value)
+#pragma warning restore S4200 // Native methods should be wrapped
+        {
+            return (float)NativeToDouble(value);
+        }
+
         /// <summary>
         /// Converts an array of 8-bit unsigned integers to its equivalent String representation encoded with base 64 digits.
         /// </summary>

--- a/source/nanoFramework.CoreLibrary/System/Double.cs
+++ b/source/nanoFramework.CoreLibrary/System/Double.cs
@@ -15,6 +15,10 @@ namespace System
     [Serializable]
     public struct Double
     {
+        internal const string _naNSymbol = "Nan";
+        internal const string _negativeInfinitySymbol = "-" + _positiveInfinitySymbol;
+        internal const string _positiveInfinitySymbol = "Infinity";
+
         // this field is required in the native end
 #pragma warning disable 0649
         internal double _value;
@@ -30,34 +34,49 @@ namespace System
         /// </summary>
         /// <remarks>The value of this constant is positive 1.7976931348623157E+308.</remarks>
         public const double MaxValue = 1.7976931348623157E+308;
+
         /// <summary>
         /// Represents the smallest positive Double value that is greater than zero. This field is constant.
         /// </summary>
         /// <remarks>The value of this constant is 4.94065645841247e-324.</remarks>
         public const double Epsilon = 4.9406564584124650E-324;
+
         /// <summary>
         /// Represents negative infinity. This field is constant.
         /// </summary>
         public const double NegativeInfinity = -1.0 / 0.0;
+
         /// <summary>
         /// Represents positive infinity. This field is constant.
         /// </summary>
         public const double PositiveInfinity = 1.0 / 0.0;
+
+#pragma warning disable S1764 // Identical expressions should not be used on both sides of a binary operator
+        // intended as the purpose is to a NaN value
+
         /// <summary>
         /// Represents a value that is not a number (NaN). This field is constant.
         /// </summary>
         public const double NaN = 0.0 / 0.0;
+#pragma warning restore S1764 // Identical expressions should not be used on both sides of a binary operator
 
         /// <summary>
-        /// Documentation missing
+        /// Compares this instance to a specified double-precision floating-point number and returns an integer that indicates whether the value of this instance is less than, equal to, or greater than the value of the specified double-precision floating-point number.
         /// </summary>
-        /// <param name="d">Documentation missing</param>
-        /// <param name="value">Documentation missing</param>
-        /// <returns>Documentation missing</returns>
+        /// <param name="d">A double-precision floating-point number to compare.</param>
+        /// <param name="value">A double-precision floating-point number to compare.</param>
+        /// <returns>A signed number indicating the relative values of this instance and value.
+        /// Less than zero: This instance is less than value. -or- This instance is not a number (<see cref="NaN"/>) and value is a number.
+        /// Zero: This instance is equal to value. -or- Both this instance and value are not a number (<see cref="NaN"/>), <see cref="PositiveInfinity"/>, or <see cref="NegativeInfinity"/>. 
+        /// Greater than zero: This instance is greater than value. -or- This instance is a number and value is not a number (<see cref="NaN"/>). 
+        /// </returns>
+        public int CompareTo(double value)
+        {
+            return CompareTo(this, value);
+        }
+
         [MethodImpl(MethodImplOptions.InternalCall)]
-#pragma warning disable S4200 // Native methods should be wrapped
-        public static extern int CompareTo(double d, double value);
-#pragma warning restore S4200 // Native methods should be wrapped
+        internal static extern int CompareTo(double d, double value);
 
         /// <summary>
         /// Returns a value indicating whether the specified number evaluates to negative or positive infinity
@@ -126,12 +145,9 @@ namespace System
         /// Converts the numeric value of this instance to its equivalent string representation.
         /// </summary>
         /// <returns>The string representation of the value of this instance.</returns>
-        public override String ToString()
+        public override string ToString()
         {
-            if (IsPositiveInfinity(this)) return "Infinity";
-            if (IsNegativeInfinity(this)) return "-Infinity";
-
-            return IsNaN(this) ? "NaN" : Number.Format(_value, false, "G", NumberFormatInfo.CurrentInfo);
+            return ToString("G");
         }
 
         /// <summary>
@@ -139,12 +155,22 @@ namespace System
         /// </summary>
         /// <param name="format">A numeric format string.</param>
         /// <returns>The string representation of the value of this instance as specified by format.</returns>
-        public String ToString(String format)
+        public string ToString(string format)
         {
-            if (IsPositiveInfinity(this)) return "Infinity";
-            if (IsNegativeInfinity(this)) return "-Infinity";
+            if (IsPositiveInfinity(this))
+            {
+                return _positiveInfinitySymbol;
+            }
+            else if (IsNegativeInfinity(this))
+            {
+                return _negativeInfinitySymbol;
+            }
+            else if (IsNaN(this))
+            {
+                return _naNSymbol;
+            }
 
-            return IsNaN(this) ? "NaN" : Number.Format(_value, false, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(_value, false, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/source/nanoFramework.CoreLibrary/System/Single.cs
+++ b/source/nanoFramework.CoreLibrary/System/Single.cs
@@ -7,6 +7,7 @@
 namespace System
 {
     using Globalization;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     /// Represents a single-precision floating-point number.
@@ -24,10 +25,12 @@ namespace System
         /// </summary>
         /// <remarks>The value of this constant is negative 3.402823e38.</remarks>
         public const float MinValue = (float)-3.40282346638528859e+38;
+
         /// <summary>
         /// Represents the smallest positive Single value that is greater than zero. This field is constant.
         /// </summary>
         public const float Epsilon = (float)1.4e-45;
+
         /// <summary>
         /// Represents the largest possible value of Single. This field is constant.
         /// </summary>
@@ -35,12 +38,109 @@ namespace System
         public const float MaxValue = (float)3.40282346638528859e+38;
 
         /// <summary>
+        /// Represents negative infinity. This field is constant.
+        /// </summary>
+        public const float NegativeInfinity = -1.0f / 0.0f;
+
+        /// <summary>
+        /// Represents positive infinity. This field is constant.
+        /// </summary>
+        public const float PositiveInfinity = 1.0f / 0.0f;
+
+#pragma warning disable S1764 // Identical expressions should not be used on both sides of a binary operator
+        // intended as the purpose is to a NaN value
+
+        /// <summary>
+        /// Represents a value that is not a number (NaN). This field is constant.
+        /// </summary>
+        public const float NaN = 0.0f / 0.0f;
+#pragma warning restore S1764 // Identical expressions should not be used on both sides of a binary operator
+
+        /// <summary>
+        /// Returns a value indicating whether the specified number evaluates to negative or positive infinity.
+        /// </summary>
+        /// <param name="f">A single-precision floating-point number. </param>
+        /// <returns>
+        /// <see langword="true"/> if f evaluates to <see cref="PositiveInfinity"/> or <see cref="NegativeInfinity"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsInfinity(float f)
+        {
+            return double.IsInfinity(f);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether the specified value is not a number (<see cref="NaN"/>).
+        /// </summary>
+        /// <param name="f">A single-precision floating-point number. </param>
+        /// <returns>
+        /// <see langword="true"/> if f evaluates to <see cref="NaN"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsNaN(float f)
+        {
+            return double.IsNaN(f);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the specified number evaluates to negative infinity.
+        /// </summary>
+        /// <param name="f">A single-precision floating-point number.</param>
+        /// <returns>
+        /// <see langword="true"/> if f evaluates to <see cref="NegativeInfinity"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsNegativeInfinity(float f)
+        {
+            return double.IsNegativeInfinity(f);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the specified number evaluates to positive infinity.
+        /// </summary>
+        /// <param name="f">A single-precision floating-point number. </param>
+        /// <returns>
+        /// <see langword="true"/> if d evaluates to <see cref="PositiveInfinity"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool IsPositiveInfinity(float f)
+        {
+            return double.IsPositiveInfinity(f);
+        }
+
+        /// <summary>
+        /// Compares this instance to a specified single-precision floating-point number and returns an integer that indicates whether the value of this instance is less than, equal to, or greater than the value of the specified single-precision floating-point number.
+        /// </summary>
+        /// <param name="f">A single-precision floating-point number to compare.</param>
+        /// <param name="value">A single-precision floating-point number to compare.</param>
+        /// <returns>A signed number indicating the relative values of this instance and value.
+        /// Less than zero: This instance is less than value. -or- This instance is not a number (<see cref="NaN"/>) and value is a number.
+        /// Zero: This instance is equal to value. -or- Both this instance and value are not a number (<see cref="NaN"/>), <see cref="PositiveInfinity"/>, or <see cref="NegativeInfinity"/>. 
+        /// Greater than zero: This instance is greater than value. -or- This instance is a number and value is not a number (<see cref="NaN"/>). 
+        /// </returns>
+        public int CompareTo(float value)
+        {
+            return double.CompareTo(this, value);
+        }
+
+        /// <summary>
+        /// Converts the string representation of a number to its single-precision floating-point number equivalent.
+        /// </summary>
+        /// <param name="s">A string that contains a number to convert. </param>
+        /// <returns>A single-precision floating-point number equivalent to the numeric value or symbol specified in <code>s</code>.</returns>
+        /// <exception cref="System.ArgumentNullException"></exception>
+        public static float Parse(string s)
+        {
+#pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one 
+            if (s == null) throw new ArgumentNullException();
+#pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one 
+
+            return Convert.ToSingle(s);
+        }
+
+        /// <summary>
         /// Converts the numeric value of this instance to its equivalent string representation.
         /// </summary>
         /// <returns>The string representation of the value of this instance.</returns>
-        public override String ToString()
+        public override string ToString()
         {
-            return Number.Format(_value, false, "G", NumberFormatInfo.CurrentInfo);
+            return ToString("G");
         }
 
         /// <summary>
@@ -48,9 +148,47 @@ namespace System
         /// </summary>
         /// <param name="format">A numeric format string.</param>
         /// <returns>The string representation of the value of this instance as specified by format.</returns>
-        public String ToString(String format)
+        public string ToString(string format)
         {
+            if (IsPositiveInfinity(this))
+            {
+                return double._positiveInfinitySymbol;
+            }
+            else if (IsNegativeInfinity(this))
+            {
+                return double._negativeInfinitySymbol;
+            }
+            else if(IsNaN(this))
+            {
+                return double._naNSymbol;
+            }
+
             return Number.Format(_value, false, format, NumberFormatInfo.CurrentInfo);
+        }
+
+        /// <summary>
+        /// Converts the string representation of a number to its single-precision floating-point number equivalent. A return value indicates whether the conversion succeeded or failed.
+        /// </summary>
+        /// <param name="s">A string containing a number to convert. </param>
+        /// <param name="result">When this method returns, contains single-precision floating-point number equivalent to the numeric value or symbol contained in s, if the conversion succeeded, or zero if the conversion failed. The conversion fails if the s parameter is <see langword="null"/> or Empty, is not a number in a valid format, or represents a number less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>. This parameter is passed uninitialized; any value originally supplied in result will be overwritten.</param>
+        /// <returns><see langword="true"/> if s was converted successfully; otherwise, <see langword="false"/>.</returns>
+        public static bool TryParse(string s, out float result)
+        {
+            result = 0.0f;
+
+            if (s == null) return false;
+
+            try
+            {
+                result = Convert.ToSingle(s);
+                return true;
+            }
+            catch
+            {
+                result = 0.0f;
+            }
+
+            return false;
         }
     }
 }

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5.0-preview.{height}",
+  "version": "1.5.1-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## Description
- Add `ToSingle()` to `Convert` class.
- Add `Parse()`,  and `TryParse()` to `Single` class.
- Add methods and properties to handle NaN and infinity to `Single` class.
- Rework `ToString()` implementations in `Single` and `Double` classes to make them more efficient.
- Replace customized version of `CompareTo()` on `Double` class and add it to `Single` to make is inline with .NET API.
- Minor rework on code style to match guidelines.
- Add missing comments for documentation for `CompareTo()` on `Double` class .
- Bump AssemblyNativeVersion to 100.4.5.0.
- Bump version to 1.5.1-preview.
- mscorlib PE size went from 34036 bytes to 34296 bytes (absolutely neglectable when considering the gains).

## Motivation and Context
- These methods in `Single` class were missing following our design decision to default native implementation to single-precision. See nanoFramework/Home#312.
- Code style wasn't following guidelines.
- Clear some more Sonarcloud issues.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
