### PR TITLE
Adds Obsolete attribute to Console methods

### DIFF
--- a/source/nanoFramework.CoreLibrary/System/Console.cs
+++ b/source/nanoFramework.CoreLibrary/System/Console.cs
@@ -22,6 +22,7 @@ namespace System
         /// Writes the specified string value to the standard output stream.
         /// </summary>
         /// <param name="value">The value to write.</param>
+        [Obsolete("This method is going to be removed in a future version. Call Debug.Write instead.")]
         public static void Write(string value)
 #pragma warning restore S4200 // Native methods should be wrapped
         {
@@ -33,6 +34,7 @@ namespace System
         /// Writes the specified string value, followed by the current line terminator, to the standard output stream.
         /// </summary>
         /// <param name="value">The value to write.</param>
+        [Obsolete("This method is going to be removed in a future version. Call Debug.Write instead.")]
         public static void WriteLine(string value)
 #pragma warning restore S4200 // Native methods should be wrapped
         {


### PR DESCRIPTION
## Description
- These methods are to be replaced by Debug.Write and WriteLine available in Runtime.Native assembly. See nanoframework/lib-nanoFramework.Runtime.Native#83.

## Motivation and Context
- Proper implementation of Write and WriteLine to output debug messages. Current implementation using Console.Write is technically wrong as that shouldn't be used in unattended applications according to .NET documentation.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
