### PR TITLE
Add IEnumerable implementation on String with exception throwing.

### DIFF
--- a/nanoFramework.CoreLibrary/System/String.cs
+++ b/nanoFramework.CoreLibrary/System/String.cs
@@ -7,6 +7,7 @@
 namespace System
 {
     using Runtime.CompilerServices;
+    using System.Collections;
     /// <summary>
     /// Represents text as a sequence of UTF-16 code units.
     /// </summary>
@@ -17,11 +18,26 @@ namespace System
     // GetHashCode() implementation is provided by general native function CLR_RT_HeapBlock::GetHashCode //
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma warning disable S1206 // "Equals(Object)" and "GetHashCode()" should be overridden in pairs
-    public sealed class String : IComparable
+    public sealed class String : IComparable, IEnumerable
 #pragma warning restore S1206 // "Equals(Object)" and "GetHashCode()" should be overridden in pairs
 #pragma warning restore CS0661 // Type defines operator == or operator != but does not override Object.GetHashCode()
 #pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
+        /// <summary>
+        /// **Not supported in NanoFramework**  
+        /// Return an enumerator that iterate on each char of the string.
+        /// </summary>
+        /// <returns>An IEnumerator object that can be used to iterate through the collection.</returns>
+        public IEnumerator GetEnumerator()
+        {
+            // Not implemented because of assembly size constraint
+            // Throw a NotSupportedException in compliance of .net practices 
+            // (no message to preserve assembly size/memory consumption)
+            // See https://docs.microsoft.com/en-us/dotnet/api/system.notsupportedexception 
+            throw new NotSupportedException(); 
+        }
+
+
         /// <summary>
         /// Represents the empty string. This field is read-only.
         /// </summary>
@@ -63,6 +79,9 @@ namespace System
         /// <returns>true if the value of a is different from the value of b; otherwise, false.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern bool operator !=(String a, String b);
+
+
+        
 
         /// <summary>
         /// Gets the Char object at a specified position in the current String object.


### PR DESCRIPTION
## Description

Adding a basic implementation of IEnumerable on String to avoid compiler crash when foreach-ing on a String.
The GetEnumator implementation only thow a NotSupportedException in order to be compliant with .net framework practices on NotImplemented/NotSupported/PlatformNotSupported exceptions.

## Motivation and Context
Iterating with foreach on a string is a common practices in c#. 
But the lake of IEnumerable implement in String class generate a compilation failure with a generic error message "CSC compiler error CS7038 'Failed to emit module'" , that is very confusing for a developper, source of lost time in debugging.

This correction remove the compiler CSC7038 error on compilation, and the developper will be quickly inform during debug that the GetEnumerator is not supported. It also add documentation and intellisense informations, improving quality of developper experience.

- Resolves nanoframework/Home#663.

## Types of changes
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change (**update**) to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
