### PR TITLE
Fixed bad test expectations in String Tests

### DIFF
--- a/Tests/NFUnitTestSystemLib/UnitTestStringTests.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestStringTests.cs
@@ -263,9 +263,9 @@ namespace NFUnitTestSystemLib
             string str1 = "@ abc@de ";
             Assert.Equal(str1.LastIndexOf('@'), 5);
             Assert.Equal(str1.LastIndexOf("abc"), 2);
-            Assert.Equal(str1.LastIndexOf('@', 1), 5);
+            Assert.Equal(str1.LastIndexOf('@', 1), 0);
             Assert.Equal(str1.LastIndexOf('@', 1, 1), -1);
-            Assert.Equal(str1.LastIndexOf("abc", 2), 2);
+            Assert.Equal(str1.LastIndexOf("abc", 2), -1);
             Assert.Equal(str1.LastIndexOf("@", 6, 1), -1);
         }
 
@@ -278,7 +278,7 @@ namespace NFUnitTestSystemLib
             char[] car1 = new Char[] { '@', 'b' };
 
             Assert.Equal(str1.LastIndexOfAny(car1), 5);
-            Assert.Equal(str1.LastIndexOfAny(car1, 1), 5);
+            Assert.Equal(str1.LastIndexOfAny(car1, 1), 0);
             Assert.Equal(str1.LastIndexOfAny(car1, 4, 1), -1);
         }
 


### PR DESCRIPTION
LastIndex* methods are searching _backwards_ from their startIndex param!

<!--- Provide a general summary of your changes in the Title above -->

## Description
Test expectations were bad.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Fixes nanoFramework/Home#710

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test commands were executed on .NET fw 4.7,2 which revealed the bad expectations.
After fixing nf corelib tests they become green.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
